### PR TITLE
[KAN-78] 음식점 조회 API에 MySQL 연결

### DIFF
--- a/src/main/kotlin/com/restaurant/be/restaurant/presentation/domain/service/GetRestaurantService.kt
+++ b/src/main/kotlin/com/restaurant/be/restaurant/presentation/domain/service/GetRestaurantService.kt
@@ -26,7 +26,7 @@ class GetRestaurantService(
     fun getRestaurants(
         request: GetRestaurantsRequest,
         pageable: Pageable,
-        email: String,
+        email: String
     ): GetRestaurantsResponse {
         val user = userRepository.findByEmail(email) ?: throw NotFoundUserEmailException()
 
@@ -40,14 +40,14 @@ class GetRestaurantService(
             restaurants.map { it.id },
             user.id ?: 0,
             request.like,
-            pageable,
+            pageable
         )
 
         return GetRestaurantsResponse(
             PageImpl(
                 restaurantProjections.content.map { it.toDto() },
                 pageable,
-                restaurantProjections.size.toLong(),
+                restaurantProjections.size.toLong()
             )
         )
     }

--- a/src/main/kotlin/com/restaurant/be/restaurant/presentation/dto/GetRestaurantDto.kt
+++ b/src/main/kotlin/com/restaurant/be/restaurant/presentation/dto/GetRestaurantDto.kt
@@ -3,6 +3,7 @@ package com.restaurant.be.restaurant.presentation.dto
 import com.restaurant.be.restaurant.presentation.dto.common.RestaurantDto
 import io.swagger.annotations.ApiModelProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.data.domain.Page
 
 data class GetRestaurantsRequest(
     @ApiModelProperty(value = "식당 이름 검색", example = "맛집", required = false)
@@ -10,9 +11,9 @@ data class GetRestaurantsRequest(
     @ApiModelProperty(value = "카테고리 필터", example = "['1', '2']", required = false)
     val categories: List<String>?,
     @ApiModelProperty(value = "킹고패스 할인 여부 필터", example = "false", required = false)
-    val discountForSkku: Boolean,
+    val discountForSkku: Boolean?,
     @ApiModelProperty(value = "평점 필터", example = "4.5", required = false)
-    val rating: Double?,
+    val ratingAvg: Double?,
     @ApiModelProperty(value = "리뷰 개수 필터", example = "100", required = false)
     val reviewCount: Int?,
     @ApiModelProperty(value = "최소 가격 필터", example = "10000", required = false)
@@ -20,7 +21,15 @@ data class GetRestaurantsRequest(
     @ApiModelProperty(value = "최대 가격 필터", example = "30000", required = false)
     val priceMax: Int?,
     @ApiModelProperty(value = "정렬 기준", example = "BASIC", required = false)
-    val sort: Sort = Sort.BASIC
+    val sort: Sort = Sort.BASIC,
+
+    @ApiModelProperty(value = "네이버 평점 필터", example = "4.5", required = false)
+    val naverRatingAvg: Double?,
+    @ApiModelProperty(value = "네이버 리뷰 개수 필터", example = "100", required = false)
+    val naverReviewCount: Int?,
+
+    @ApiModelProperty(value = "찜 필터", example = "false", required = false)
+    val like: Boolean?,
 )
 
 enum class Sort {
@@ -33,7 +42,7 @@ enum class Sort {
 
 data class GetRestaurantsResponse(
     @Schema(description = "식당 리스트")
-    val restaurants: List<RestaurantDto>
+    val restaurants: Page<RestaurantDto>
 )
 
 data class GetRestaurantResponse(

--- a/src/main/kotlin/com/restaurant/be/restaurant/presentation/dto/GetRestaurantDto.kt
+++ b/src/main/kotlin/com/restaurant/be/restaurant/presentation/dto/GetRestaurantDto.kt
@@ -29,7 +29,7 @@ data class GetRestaurantsRequest(
     val naverReviewCount: Int?,
 
     @ApiModelProperty(value = "찜 필터", example = "false", required = false)
-    val like: Boolean?,
+    val like: Boolean?
 )
 
 enum class Sort {

--- a/src/main/kotlin/com/restaurant/be/restaurant/repository/RestaurantEsRepository.kt
+++ b/src/main/kotlin/com/restaurant/be/restaurant/repository/RestaurantEsRepository.kt
@@ -140,7 +140,7 @@ class RestaurantEsRepository(
                     }
                 },
                 size = 500,
-                from = 0,
+                from = 0
             ).parseHits<RestaurantEsDocument>()
         }
 

--- a/src/main/kotlin/com/restaurant/be/restaurant/repository/RestaurantEsRepository.kt
+++ b/src/main/kotlin/com/restaurant/be/restaurant/repository/RestaurantEsRepository.kt
@@ -32,11 +32,11 @@ class RestaurantEsRepository(
                 dsl.terms("category", *request.categories.toTypedArray())
             )
         }
-        if (request.discountForSkku) {
+        if (request.discountForSkku == true) {
             termQueries.add(
                 dsl.exists("discount_content")
             )
-        } else {
+        } else if (request.discountForSkku == false) {
             termQueries.add(
                 dsl.bool {
                     mustNot(
@@ -45,17 +45,31 @@ class RestaurantEsRepository(
                 }
             )
         }
-        if (request.rating != null) {
+        if (request.ratingAvg != null) {
             termQueries.add(
-                dsl.range("naver_rating") {
-                    gte = request.rating
+                dsl.range("rating_avg") {
+                    gte = request.ratingAvg
                 }
             )
         }
         if (request.reviewCount != null) {
             termQueries.add(
-                dsl.range("naver_review_count") {
+                dsl.range("review_count") {
                     gte = request.reviewCount
+                }
+            )
+        }
+        if (request.naverRatingAvg != null) {
+            termQueries.add(
+                dsl.range("naver_rating_avg") {
+                    gte = request.naverRatingAvg
+                }
+            )
+        }
+        if (request.naverReviewCount != null) {
+            termQueries.add(
+                dsl.range("naver_review_count") {
+                    gte = request.naverReviewCount
                 }
             )
         }
@@ -125,8 +139,8 @@ class RestaurantEsRepository(
                         }
                     }
                 },
-                size = pageable.pageSize,
-                from = pageable.offset.toInt()
+                size = 500,
+                from = 0,
             ).parseHits<RestaurantEsDocument>()
         }
 

--- a/src/main/kotlin/com/restaurant/be/restaurant/repository/RestaurantRepositoryCustom.kt
+++ b/src/main/kotlin/com/restaurant/be/restaurant/repository/RestaurantRepositoryCustom.kt
@@ -1,7 +1,15 @@
 package com.restaurant.be.restaurant.repository
 
 import com.restaurant.be.restaurant.repository.dto.RestaurantProjectionDto
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 interface RestaurantRepositoryCustom {
     fun findDtoById(restaurantId: Long): RestaurantProjectionDto?
+    fun findDtoByIds(
+        restaurantIds: List<Long>,
+        userId: Long,
+        isLikeFilter: Boolean?,
+        pageable: Pageable,
+    ): Page<RestaurantProjectionDto>
 }

--- a/src/main/kotlin/com/restaurant/be/restaurant/repository/RestaurantRepositoryCustom.kt
+++ b/src/main/kotlin/com/restaurant/be/restaurant/repository/RestaurantRepositoryCustom.kt
@@ -10,6 +10,6 @@ interface RestaurantRepositoryCustom {
         restaurantIds: List<Long>,
         userId: Long,
         isLikeFilter: Boolean?,
-        pageable: Pageable,
+        pageable: Pageable
     ): Page<RestaurantProjectionDto>
 }

--- a/src/main/kotlin/com/restaurant/be/restaurant/repository/RestaurantRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/restaurant/be/restaurant/repository/RestaurantRepositoryCustomImpl.kt
@@ -1,5 +1,6 @@
 package com.restaurant.be.restaurant.repository
 
+import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.restaurant.be.restaurant.presentation.domain.entity.QCategory.category
 import com.restaurant.be.restaurant.presentation.domain.entity.QMenu.menu
@@ -9,6 +10,9 @@ import com.restaurant.be.restaurant.presentation.domain.entity.QRestaurantLike.r
 import com.restaurant.be.restaurant.repository.dto.RestaurantProjectionDto
 import com.restaurant.be.review.domain.entity.QReview.review
 import com.restaurant.be.user.domain.entity.QUser.user
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 
 class RestaurantRepositoryCustomImpl(
     private val queryFactory: JPAQueryFactory
@@ -59,5 +63,78 @@ class RestaurantRepositoryCustomImpl(
         } else {
             null
         }
+    }
+
+    override fun findDtoByIds(
+        restaurantIds: List<Long>,
+        userId: Long,
+        isLikeFilter: Boolean?,
+        pageable: Pageable,
+    ): Page<RestaurantProjectionDto> {
+        val restaurantQuery = queryFactory
+            .select(restaurant)
+            .from(restaurant)
+            .where(restaurant.id.`in`(restaurantIds)
+                .and(
+                    if (isLikeFilter == true) restaurant.id.`in`(
+                        JPAExpressions
+                            .select(restaurantLike.restaurantId)
+                            .from(restaurantLike)
+                            .where(restaurantLike.userId.eq(userId))
+                    ) else null
+                )
+            )
+
+        val total = restaurantQuery.fetchCount()
+
+        val restaurantInfos = restaurantQuery
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        val likedUsers = queryFactory
+            .select(restaurantLike)
+            .from(restaurantLike)
+            .where(restaurantLike.userId.eq(userId))
+            .fetch()
+
+        val menus = queryFactory
+            .select(menu)
+            .from(menu)
+            .where(menu.restaurantId.`in`(restaurantIds))
+            .fetch()
+
+        val reviews = queryFactory
+            .select(review)
+            .from(review)
+            .where(review.restaurantId.`in`(restaurantIds))
+            .orderBy(review.likeCount.desc())
+            .fetch()
+
+        val categories = queryFactory
+            .select(restaurantCategory, category)
+            .from(restaurantCategory)
+            .leftJoin(category).on(restaurantCategory.categoryId.eq(category.id))
+            .where(restaurantCategory.restaurantId.`in`(restaurantIds))
+            .fetch()
+
+        val restaurantDtos = restaurantInfos.map { restaurantInfo ->
+            val likedUserIds =
+                likedUsers.filter { it.restaurantId == restaurantInfo.id }.map { it.id }
+            val menuList = menus.filter { it.restaurantId == restaurantInfo.id }
+            val review = reviews.firstOrNull { it.restaurantId == restaurantInfo.id }
+            val categoryList = categories
+                .filter { it.get(restaurantCategory.restaurantId) == restaurantInfo.id }
+                .mapNotNull { it.get(category) }
+            RestaurantProjectionDto(
+                restaurantInfo,
+                likedUserIds.isNotEmpty(),
+                menuList,
+                review,
+                categoryList
+            )
+        }
+
+        return PageImpl(restaurantDtos, pageable, total)
     }
 }

--- a/src/main/kotlin/com/restaurant/be/restaurant/repository/RestaurantRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/restaurant/be/restaurant/repository/RestaurantRepositoryCustomImpl.kt
@@ -69,20 +69,25 @@ class RestaurantRepositoryCustomImpl(
         restaurantIds: List<Long>,
         userId: Long,
         isLikeFilter: Boolean?,
-        pageable: Pageable,
+        pageable: Pageable
     ): Page<RestaurantProjectionDto> {
         val restaurantQuery = queryFactory
             .select(restaurant)
             .from(restaurant)
-            .where(restaurant.id.`in`(restaurantIds)
-                .and(
-                    if (isLikeFilter == true) restaurant.id.`in`(
-                        JPAExpressions
-                            .select(restaurantLike.restaurantId)
-                            .from(restaurantLike)
-                            .where(restaurantLike.userId.eq(userId))
-                    ) else null
-                )
+            .where(
+                restaurant.id.`in`(restaurantIds)
+                    .and(
+                        if (isLikeFilter == true) {
+                            restaurant.id.`in`(
+                                JPAExpressions
+                                    .select(restaurantLike.restaurantId)
+                                    .from(restaurantLike)
+                                    .where(restaurantLike.userId.eq(userId))
+                            )
+                        } else {
+                            null
+                        }
+                    )
             )
 
         val total = restaurantQuery.fetchCount()

--- a/src/main/kotlin/com/restaurant/be/restaurant/repository/dto/RestaurantEsDocument.kt
+++ b/src/main/kotlin/com/restaurant/be/restaurant/repository/dto/RestaurantEsDocument.kt
@@ -20,7 +20,7 @@ data class RestaurantEsDocument(
     @SerialName("discount_content") val discountContent: String?,
     @SerialName("menus") val menus: List<MenuEsDocument>,
     @SerialName("review_count") val reviewCount: Long,
-    @SerialName("rating_avg") val ratingAvg: Double?,
+    @SerialName("rating_avg") val ratingAvg: Double?
 ) {
     fun toDto() = RestaurantDto(
         id = id,

--- a/src/main/kotlin/com/restaurant/be/restaurant/repository/dto/RestaurantEsDocument.kt
+++ b/src/main/kotlin/com/restaurant/be/restaurant/repository/dto/RestaurantEsDocument.kt
@@ -14,12 +14,13 @@ data class RestaurantEsDocument(
     @SerialName("original_category") val originalCategory: String,
     @SerialName("naver_review_count") val naverReviewCount: Long,
     @SerialName("address") val address: String,
-    @SerialName("naver_rating") val naverRating: Double?,
-    @SerialName("number") val number: String,
+    @SerialName("naver_rating_avg") val naverRating: Double?,
     @SerialName("image_url") val imageUrl: String,
     @SerialName("category") val category: String,
     @SerialName("discount_content") val discountContent: String?,
-    @SerialName("menus") val menus: List<MenuEsDocument>
+    @SerialName("menus") val menus: List<MenuEsDocument>,
+    @SerialName("review_count") val reviewCount: Long,
+    @SerialName("rating_avg") val ratingAvg: Double?,
 ) {
     fun toDto() = RestaurantDto(
         id = id,
@@ -36,7 +37,7 @@ data class RestaurantEsDocument(
         isLike = false, // RDB
         discountContent = discountContent, // 나중에 추가
         detailInfo = RestaurantDetailDto(
-            contactNumber = number,
+            contactNumber = "",
             address = address,
             menus = menus.map { it.toDto() },
             operatingInfos = emptyList() // 나중에 추가


### PR DESCRIPTION
- 정렬 처리 남음.

찜한 데이터를 위해서 아래 개선도 필요함

### AS-IS
1. ES에서 모든 데이터를 조회 (찜 필터 제외한 필터는 여기서 모두 적용)
2. ES에서 전달받은 데이터를 MySQL로 id in절 쿼리 + 찜 필터

### TO-BE
1. MySQL로 찜 필터 선처리 
2. ES에서 찜처리된 데이터를 기반으로 필터 처리 + 정렬 로직 
3. MySQL에서 in 절 쿼리 


시간 여유가 살짝 있으니, 테스트코드 작성 후 개선하는것도 고려.
